### PR TITLE
추가: #133 팀 상태 변경을 위한 batch controller 추가

### DIFF
--- a/src/main/java/io/seoul/helper/config/auth/WebSecurityConfig.java
+++ b/src/main/java/io/seoul/helper/config/auth/WebSecurityConfig.java
@@ -23,6 +23,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .permitAll()
                 .antMatchers(HttpMethod.GET, "/api/v1/**")
                 .permitAll()
+                .antMatchers(HttpMethod.POST, "/api/v1/batch/**")
+                .permitAll()
                 .antMatchers("/api/v1/**").hasAnyRole(Role.USER.name(), Role.ADMIN.name())
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/io/seoul/helper/controller/BatchController.java
+++ b/src/main/java/io/seoul/helper/controller/BatchController.java
@@ -1,0 +1,47 @@
+package io.seoul.helper.controller;
+
+import io.seoul.helper.controller.dto.ResultResponseDto;
+import io.seoul.helper.controller.team.dto.TeamResponseDto;
+import io.seoul.helper.service.TeamService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.persistence.EntityNotFoundException;
+import java.util.List;
+
+@Slf4j
+@RestController
+public class BatchController {
+    @Autowired
+    private TeamService teamService;
+
+    @PostMapping(value = "/api/v1/batch/teams/status")
+    public ResultResponseDto updateTeamStatus() {
+        List<TeamResponseDto> data;
+        try {
+            data = teamService.updateTeamsLessThanCurrentTime();
+        } catch (EntityNotFoundException e) {
+            log.info("not found team status : " + e.getMessage() + "\n\n" + e.getCause());
+            return ResultResponseDto.builder()
+                    .statusCode(HttpStatus.OK.value())
+                    .message(e.getMessage())
+                    .data(null)
+                    .build();
+        } catch (Exception e) {
+            log.error("failed to update team status : " + e.getMessage() + "\n\n" + e.getCause());
+            return ResultResponseDto.builder()
+                    .statusCode(HttpStatus.OK.value())
+                    .message(e.getMessage())
+                    .data(null)
+                    .build();
+        }
+        return ResultResponseDto.builder()
+                .statusCode(HttpStatus.OK.value())
+                .message("OK")
+                .data(data)
+                .build();
+    }
+}

--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -14,6 +14,8 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.time.LocalDateTime;
+
 @Controller
 public class PageController {
     @Autowired
@@ -26,11 +28,13 @@ public class PageController {
     public String home(Model model, @LoginUser SessionUser user) {
         if (user == null) {
             TeamListRequestDto dto = new TeamListRequestDto();
+            dto.setStartTime(LocalDateTime.now());
             Page<TeamResponseDto> teams = teamService.findTeams(dto);
             model.addAttribute("teams", teams);
         }
         if (user != null) {
             TeamListRequestDto allTeamDto = new TeamListRequestDto();
+            allTeamDto.setStartTime(LocalDateTime.now());
             Page<TeamResponseDto> allTeams = teamService.findTeams(allTeamDto);
             model.addAttribute("allTeams", allTeams);
 
@@ -52,6 +56,7 @@ public class PageController {
                            @RequestParam(value = "offset", required = false, defaultValue = "0") int offset) {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setOffset(offset);
+        dto.setStartTime(LocalDateTime.now());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 
         model.addAttribute("teams", teams);
@@ -105,6 +110,7 @@ public class PageController {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setStatus(status);
         dto.setOffset(offset);
+        dto.setStartTime(LocalDateTime.now());
         dto.setExcludeNickname(user.getNickname());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 

--- a/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
+++ b/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
@@ -39,4 +39,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "t.id NOT IN :teamId")
     Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTime, LocalDateTime endTime, TeamStatus status,
                                       TeamLocation location, List<Long> teamId, Pageable pageable);
+
+    List<Team> findTeamsByStatusNotAndEndTimeLessThan(TeamStatus location, LocalDateTime currentTime);
 }

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -81,6 +81,23 @@ public class TeamService {
     }
 
     @Transactional
+    public List<TeamResponseDto> updateTeamsLessThanCurrentTime() throws Exception {
+        LocalDateTime currentTime = LocalDateTime.now();
+        List<Team> teams = teamRepo.findTeamsByStatusNotAndEndTimeLessThan(TeamStatus.END, currentTime);
+
+        if (teams.isEmpty()) {
+            throw new EntityNotFoundException("nothing to change teams");
+        }
+        for (Team team : teams) {
+            team.updateTeamEnd();
+        }
+        teams = teamRepo.saveAll(teams);
+
+        return teams.stream().map(team -> new TeamResponseDto(team))
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
     public void joinTeam(SessionUser sessionUser, Long id) throws Exception {
         User user = findUser(sessionUser);
         Team team = findTeam(id);


### PR DESCRIPTION
`POST /api/v1/batch/teams/status` 로 요청시 현재시간과 종료시간을 비교하여, 팀의 상태를 `END` 로 바꿉니다.

```
{
    "statusCode": 200,
    "message": "nothing to change teams",
    "data": null
}
```

바꿀 값이 없을경우 위와 같은 값이 반환됩니다.


추가로 현재시간과 시작시간을 비교하여, 일부 페이지에서 시간이 지난 팀들은 보이지 않게 하였습니다.
Status 여러개 혹은 단일로 필터하는 방법을 생각했으나, 서비스 로직 수정이나 dto 변경등이 복잡해 질것으로 생각되어, 현재 구현되어있는 startTime 비교 옵션을 사용하여 보이지 않게 하였습니다.
PageController에 `setStartTime(LocalDateTime.now());` 를 추가시켰으므로 확인 부탁드립니다.

적용범위: `현재 멘토링 대기중인 모든 팀`, `팀 만들기`, `모든 팀`


related: #133