### PR TITLE
수정: #160 멘토가 팀만들기시에 READY 상태가 되도록 수정

### DIFF
--- a/src/main/java/io/seoul/helper/domain/team/Team.java
+++ b/src/main/java/io/seoul/helper/domain/team/Team.java
@@ -52,9 +52,7 @@ public class Team {
         this.project = project;
     }
 
-    public void updateTeamReady(Period period, Long maxMemberCount) {
-        this.period = period;
-        this.maxMemberCount = maxMemberCount;
+    public void updateTeamReady() {
         this.status = TeamStatus.READY;
     }
 

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -73,6 +73,7 @@ public class TeamService {
         if (!period.isValid() || !period.isInRanged(team.getPeriod()))
             throw new IllegalArgumentException("Invalid Time");
         team.updateTeam(period, requestDto.getMaxMemberCount(), requestDto.getLocation(), project);
+        team.updateTeamReady();
         team = teamRepo.save(team);
         memberRepo.save(Member.builder()
                 .team(team)


### PR DESCRIPTION
기존 Team Entity에 존재하는 updateTeamReady()를 수정하였습니다.
사용하는곳이 없기때문에 변경하는 방식으로 처리했습니다.
Period period, Long maxMemberCount를 인수를 사용하는 곳이 예정되어 있었다면 오버로딩으로 처리하겠습니다.

이슈: #160 