### PR TITLE
버그:등록된 팀이 하나도 없을 경우 모든 목록이 보이지 않는 증상 수정

### DIFF
--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -203,9 +203,16 @@ public class TeamService {
             } else if (requestDto.getExcludeNickname() != null) {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getExcludeNickname(), requestDto.isCreateor());
 
-                teams = teamRepo.findTeamsByTeamIdNotIn(
-                        requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
-                        requestDto.getLocation(), teamIds, pageable);
+                if (teamIds.isEmpty()) {
+                    teams = teamRepo.findTeamsByQueryParameters(
+                            requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                            requestDto.getLocation(), pageable);
+                } else {
+                    teams = teamRepo.findTeamsByTeamIdNotIn(
+                            requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                            requestDto.getLocation(), teamIds, pageable);
+                }
+
             } else {
                 teams = teamRepo.findTeamsByQueryParameters(
                         requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),


### PR DESCRIPTION
### 원인
mariadb 와 h2 database에서 JPQL이 다르게 작동이 생기는 버그 같습니다.

### 재현 과정
서버의 증상을 localhost 에서 재현해 보고자 들어간 DDL과 DML을 똑같이 넣어보았으나 정상적으로 잘 동작했습니다.
그러나 h2를 mariadb로 변경해서 적용해보니 버그와 똑같이 재현할 수 있었습니다.

### 바뀐내용
JPQL에서 처리해보고자 하였으나, 생각한대로 잘 동작하지 않아 일단 코드 레벨에서 수정하였습니다.

이슈:  #182
