### PR TITLE
수정: #206 EndTime이 지난 팀들은 보이지 않게 수정함

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -28,18 +28,19 @@ public class PageController {
     public String home(Model model, @LoginUser SessionUser user) {
         if (user == null) {
             TeamListRequestDto dto = new TeamListRequestDto();
-            dto.setStartTime(LocalDateTime.now());
+            dto.setStartTimePrevious(LocalDateTime.now());
             Page<TeamResponseDto> teams = teamService.findTeams(dto);
             model.addAttribute("teams", teams);
         }
         if (user != null) {
             TeamListRequestDto allTeamDto = new TeamListRequestDto();
-            allTeamDto.setStartTime(LocalDateTime.now());
+            allTeamDto.setStartTimePrevious(LocalDateTime.now());
             allTeamDto.setExcludeNickname(user.getNickname());
             Page<TeamResponseDto> allTeams = teamService.findTeams(allTeamDto);
             model.addAttribute("allTeams", allTeams);
 
             TeamListRequestDto myTeamDto = new TeamListRequestDto();
+            myTeamDto.setEndTimePrevious(LocalDateTime.now());
             myTeamDto.setNickname(user.getNickname());
             Page<TeamResponseDto> myTeams = teamService.findTeams(myTeamDto);
             model.addAttribute("myTeams", myTeams);
@@ -57,7 +58,7 @@ public class PageController {
                            @RequestParam(value = "offset", required = false, defaultValue = "0") int offset) {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setOffset(offset);
-        dto.setStartTime(LocalDateTime.now());
+        dto.setStartTimePrevious(LocalDateTime.now());
         dto.setExcludeNickname(user.getNickname());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 
@@ -75,6 +76,7 @@ public class PageController {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setNickname(user.getNickname());
         dto.setOffset(offset);
+        dto.setEndTimePrevious(LocalDateTime.now());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 
         model.addAttribute("teams", teams);
@@ -97,6 +99,7 @@ public class PageController {
         dto.setCreateor(true);
         dto.setOffset(offset);
         dto.setStatus(TeamStatus.WAITING);
+        dto.setEndTimePrevious(LocalDateTime.now());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
         model.addAttribute("teams", teams);
         model.addAttribute("projects", projectService.findAllProjects());
@@ -113,7 +116,7 @@ public class PageController {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setStatus(status);
         dto.setOffset(offset);
-        dto.setStartTime(LocalDateTime.now());
+        dto.setStartTimePrevious(LocalDateTime.now());
         dto.setExcludeNickname(user.getNickname());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 

--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
@@ -20,10 +20,10 @@ public class TeamListRequestDto {
     private TeamLocation location;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime startTime;
+    private LocalDateTime startTimePrevious;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
-    private LocalDateTime endTime;
+    private LocalDateTime endTimePrevious;
 
     public TeamListRequestDto() {
         this.offset = 0;

--- a/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
+++ b/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
@@ -18,7 +18,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime < :endTime)")
+            "(:endTime is null or t.period.endTime > :endTime)")
     Page<Team> findTeamsByQueryParameters(LocalDateTime startTime, LocalDateTime endTime,
                                           TeamStatus status, TeamLocation location, Pageable pageable);
 
@@ -26,7 +26,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime < :endTime) and " +
+            "(:endTime is null or t.period.endTime > :endTime) and " +
             "t.id IN :teamId")
     Page<Team> findTeamsByTeamIdIn(LocalDateTime startTime, LocalDateTime endTime, TeamStatus status,
                                    TeamLocation location, List<Long> teamId, Pageable pageable);
@@ -35,7 +35,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime < :endTime) and " +
+            "(:endTime is null or t.period.endTime > :endTime) and " +
             "t.id NOT IN :teamId")
     Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTime, LocalDateTime endTime, TeamStatus status,
                                       TeamLocation location, List<Long> teamId, Pageable pageable);

--- a/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
+++ b/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
@@ -17,27 +17,27 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("SELECT t FROM Team t " +
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
-            "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime > :endTime)")
-    Page<Team> findTeamsByQueryParameters(LocalDateTime startTime, LocalDateTime endTime,
+            "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
+            "(:endTimePrevious is null or t.period.endTime > :endTimePrevious)")
+    Page<Team> findTeamsByQueryParameters(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious,
                                           TeamStatus status, TeamLocation location, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
-            "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime > :endTime) and " +
+            "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
+            "(:endTimePrevious is null or t.period.endTime > :endTimePrevious) and " +
             "t.id IN :teamId")
-    Page<Team> findTeamsByTeamIdIn(LocalDateTime startTime, LocalDateTime endTime, TeamStatus status,
+    Page<Team> findTeamsByTeamIdIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious, TeamStatus status,
                                    TeamLocation location, List<Long> teamId, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +
             "WHERE (:status is null or t.status = :status) and " +
             "(:location is null or t.location = :location) and " +
-            "(:startTime is null or t.period.startTime > :startTime) and " +
-            "(:endTime is null or t.period.endTime > :endTime) and " +
+            "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
+            "(:endTimePrevious is null or t.period.endTime > :endTimePrevious) and " +
             "t.id NOT IN :teamId")
-    Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTime, LocalDateTime endTime, TeamStatus status,
+    Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious, TeamStatus status,
                                       TeamLocation location, List<Long> teamId, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -200,24 +200,24 @@ public class TeamService {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getNickname(), requestDto.isCreateor());
 
                 teams = teamRepo.findTeamsByTeamIdIn(
-                        requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
                         requestDto.getLocation(), teamIds, pageable);
             } else if (requestDto.getExcludeNickname() != null) {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getExcludeNickname(), requestDto.isCreateor());
 
                 if (teamIds.isEmpty()) {
                     teams = teamRepo.findTeamsByQueryParameters(
-                            requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
                             requestDto.getLocation(), pageable);
                 } else {
                     teams = teamRepo.findTeamsByTeamIdNotIn(
-                            requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
                             requestDto.getLocation(), teamIds, pageable);
                 }
 
             } else {
                 teams = teamRepo.findTeamsByQueryParameters(
-                        requestDto.getStartTime(), requestDto.getEndTime(), requestDto.getStatus(),
+                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
                         requestDto.getLocation(), pageable);
             }
         } catch (Exception e) {


### PR DESCRIPTION
`참여를 기다리고 있는 팀`, `모든 팀 목록`, `멘토 신청` 페이지는 startTime 을 기준으로 현재시간 전까지 조회가 됩니다. (기존 적용 내용)
이번에 추가한 `멘티 신청`,` 내가 속한팀`,  `나의 팀` 페이지는 endTime을 기준으로 현재시간 전까지 조회가됩니다. (새로 추가한 내용)

이렇게 구분을 해놓은 이유는 종료가 되기전까지는 팀을 조회할 수 있어야하기 때문입니다.


기획을 하다보니 수정한 코드가 많아지긴 했지만,  repo에서 `좀 더 의미 있게 변수명 변경` 하였습니다. 

이슈: #206