### PR TITLE
추가: #202 단일 정렬 기능 구현 및 홈화면에서 시간순으로 보이도록 수정

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -41,6 +41,7 @@ public class PageController {
 
             TeamListRequestDto myTeamDto = new TeamListRequestDto();
             myTeamDto.setNickname(user.getNickname());
+            myTeamDto.setSort("period.startTime,asc");
             Page<TeamResponseDto> myTeams = teamService.findTeams(myTeamDto);
             model.addAttribute("myTeams", myTeams);
 

--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
@@ -18,6 +18,7 @@ public class TeamListRequestDto {
     private boolean isCreateor;
     private TeamStatus status;
     private TeamLocation location;
+    private String sort;
 
     @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime startTime;
@@ -28,5 +29,6 @@ public class TeamListRequestDto {
     public TeamListRequestDto() {
         this.offset = 0;
         this.limit = 10;
+        this.sort = "id,desc";
     }
 }

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -189,12 +189,30 @@ public class TeamService {
         teamRepo.delete(team);
     }
 
+    private Pageable toPageable(int offset, int limit, String sort) throws Exception {
+        Pageable pageable;
+        try {
+            if (sort.contains(",")) {
+                String[] sortOption = sort.split(",");
+                pageable = PageRequest.of(
+                        offset, limit,
+                        sortOption[1].equals("asc") ? Sort.Direction.ASC : Sort.Direction.DESC,
+                        sortOption[0]);
+            } else {
+                pageable = PageRequest.of(
+                        offset, limit, Sort.Direction.DESC, sort);
+            }
+        } catch (Exception e) {
+            throw new Exception("failed to Pageable");
+        }
+        return pageable;
+    }
+
     @Transactional
     public Page<TeamResponseDto> findTeams(TeamListRequestDto requestDto) {
         Page<Team> teams;
         try {
-            Pageable pageable = PageRequest.of(
-                    requestDto.getOffset(), requestDto.getLimit(), Sort.Direction.DESC, "id");
+            Pageable pageable = toPageable(requestDto.getOffset(), requestDto.getLimit(), requestDto.getSort());
 
             if (requestDto.getNickname() != null) {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getNickname(), requestDto.isCreateor());


### PR DESCRIPTION
`http://localhost:8080/api/v1/teams?sort=period.startTime` 혹은 
`http://localhost:8080/api/v1/teams?sort=period.startTime,asc` 와 같은 방식으로 정렬을 할 수 있습니다.

`http://localhost:8080/api/v1/teams?sort=status` enum도 정렬이 됩니다.

Entitiy에 있는 모든 객체를 전부 정렬 할 수 있습니다. 중간에 이상한 값이 생길 경우 exception이 발생하며 null 데이터가 반환됩니다.

이슈: #202 