### PR TITLE
FIX: #233 modal input 보수

### DIFF
--- a/src/main/resources/templates/fragment/team_create_modal.html
+++ b/src/main/resources/templates/fragment/team_create_modal.html
@@ -28,6 +28,7 @@
                                             th:value="${proj.id}"
                                             th:utext="${proj.name}"></option>
                                 </select>
+                                <div class="invalid-feedback">프로젝트를 선택해주세요.</div>
                             </div>
                         </div>
 
@@ -41,6 +42,7 @@
                                             th:utext="${loc.name}"></option>
                                     </option>
                                 </select>
+                                <div class="invalid-feedback">장소를 선택해주세요.</div>
                             </div>
                         </div>
                     </div>
@@ -49,13 +51,17 @@
                             <div class="mb-3">
                                 <label for="tc_input_max_member_count" class="form-label">참여 인원</label>
                                 <input class="form-control" id="tc_input_max_member_count" th:type="number"
-                                       th:min="2" required>
+                                       th:min="2" th:max="100" pattern="^[0-9]*$" required/>
+                                <div class="invalid-feedback">인원수는 "2 ~ 100" 사이의 숫자값만 입력해주세요.</div>
                             </div>
                         </div>
                         <div class="col-6">
                             <div class="mb-3">
                                 <label for="tc_input_datepicker" class="form-label">날짜</label>
-                                <input id="tc_input_datepicker" class="form-control" required autocomplete="off"/>
+                                <input id="tc_input_datepicker" class="form-control" autocomplete="off"
+                                       pattern="^(19|20)\d{2}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[0-1])$"
+                                       required/>
+                                <div class="invalid-feedback">날짜는 "yyyy-mm-dd" 형식으로 입력해주세요.</div>
                             </div>
                         </div>
                     </div>
@@ -85,8 +91,18 @@
 <div th:fragment="script">
     <script>
         var tc_ajax_req_info = undefined;
-        var tc_team = undefined;
         var tc_startDate = new Date(2020, 0, 1, 0, 0, 0).valueOf();
+
+        //input number only number
+        $('.numeric-only').keyup(function (e) {
+            regNumber = /^[0-9]*$/;
+            var str = $(this).val();
+            if (!regNumber.test(str)) {
+                var res = str.substring(0, str.length - 1);
+                $(this).val(res);
+            }
+        });
+
 
         $("#tc_input_time_rangeslider").ionRangeSlider({
             skin: "round",
@@ -101,7 +117,7 @@
                 var m = moment(ts);
 
                 m.toISOString();
-                if (m.hour() == 0 && tc_startDate < ts)
+                if (m.hour() == 0 && m.minute() == 0 && tc_startDate < ts)
                     return "24:00";
                 else
                     return m.format("HH:mm");
@@ -141,7 +157,7 @@
             $memberList.empty();
 
             tc_time_rangeslider.update({
-                min: timeToTS(moment(new Date(2020, 0, 1, 0, 0, 1))),
+                min: timeToTS(moment(new Date(2020, 0, 1, 0, 0, 0))),
                 max: timeToTS(moment(new Date(2020, 0, 2, 0, 0, 0))),
                 from: timeToTS(moment(new Date(2020, 0, 1, 6, 0, 0))),
                 to: timeToTS(moment(new Date(2020, 0, 1, 18, 0, 0)))

--- a/src/main/resources/templates/fragment/team_matching_modal.html
+++ b/src/main/resources/templates/fragment/team_matching_modal.html
@@ -101,7 +101,7 @@
                 var m = moment(ts);
 
                 m.toISOString();
-                if (m.hour() == 0 && tm_startDate < ts)
+                if (m.hour() == 0 && m.minute() == 0 && tm_startDate < ts)
                     return "24:00";
                 else
                     return m.format("HH:mm");

--- a/src/main/resources/templates/fragment/team_viewer_modal.html
+++ b/src/main/resources/templates/fragment/team_viewer_modal.html
@@ -101,7 +101,7 @@
                 var m = moment(ts);
 
                 m.toISOString();
-                if (m.hour() == 0 && tv_startDate < ts)
+                if (m.hour() == 0 && m.minute() == 0 && tv_startDate < ts)
                     return "24:00";
                 else
                     return m.format("HH:mm");
@@ -137,7 +137,7 @@
                     var m = moment(ts);
 
                     m.toISOString();
-                    if (m.hour() == 0 && tv_startDate < ts)
+                    if (m.hour() == 0 && m.minute() == 0 && tv_startDate < ts)
                         return "24:00";
                     else
                         return m.format("HH:mm");


### PR DESCRIPTION
Fix: 시간 출력 중 00:00 ~ 00:45의 시간이 정상 표기 되지 않는 버그 수정
Fix: max_people_count의 입력이 지수, 실수 등의 값이 들어가는 버그 수정

시간을 문자열로 출력하주는 function의 예외조건 처리가 미흡하여
시간출력 버그가 발생했습니다.
function의 시간 조건에 시, 분이 각각 0 일때만 24:00이 되도록 수정 하였습니다.

max_people_count, datepicker에 format을 추가하여 입력값을 제한했습니다.

max_people_count 의 max값을 조정했습니다.

이제 값을 입력하지 않거나 입력값이 잘못 되어있다면 validation 문구가
표기됩니다.