### PR TITLE
FIX: #230 home 화면에서 표시되는 팀 정보 버튼 설정

### DIFF
--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamMemberDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamMemberDto.java
@@ -7,9 +7,11 @@ import lombok.Getter;
 public class TeamMemberDto {
     private String nickname;
     private String memberRole;
+    private Boolean isCreator;
 
     public TeamMemberDto(Member member) {
         this.nickname = member.getUser().getNickname();
         this.memberRole = member.getRole().getName();
+        this.isCreator = member.getCreator();
     }
 }

--- a/src/main/java/io/seoul/helper/controller/user/UserApiController.java
+++ b/src/main/java/io/seoul/helper/controller/user/UserApiController.java
@@ -1,0 +1,29 @@
+package io.seoul.helper.controller.user;
+
+import io.seoul.helper.config.auth.LoginUser;
+import io.seoul.helper.config.auth.dto.SessionUser;
+import io.seoul.helper.controller.dto.ResultResponseDto;
+import io.seoul.helper.controller.user.dto.UserResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserApiController {
+
+    @GetMapping(value = "/api/v1/user/current")
+    public ResultResponseDto getCurrentUser(@LoginUser SessionUser sessionUser) {
+        UserResponseDto user = null;
+        if (sessionUser != null)
+            user = UserResponseDto.builder()
+                    .nickname(sessionUser.getNickname())
+                    .name(sessionUser.getNickname())
+                    .email(sessionUser.getEmail())
+                    .build();
+        return ResultResponseDto.builder()
+                .statusCode(HttpStatus.OK.value())
+                .message(HttpStatus.OK.name())
+                .data(user)
+                .build();
+    }
+}

--- a/src/main/java/io/seoul/helper/controller/user/dto/UserResponseDto.java
+++ b/src/main/java/io/seoul/helper/controller/user/dto/UserResponseDto.java
@@ -1,0 +1,19 @@
+package io.seoul.helper.controller.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UserResponseDto {
+    private String name;
+    private String email;
+    private String nickname;
+
+    @Builder
+    public UserResponseDto(String name, String email, String nickname) {
+        this.name = name;
+        this.email = email;
+        this.nickname = nickname;
+    }
+}

--- a/src/main/resources/templates/fragment/team_create_modal.html
+++ b/src/main/resources/templates/fragment/team_create_modal.html
@@ -75,7 +75,7 @@
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
                 <button type="button" class="btn btn-primary" id="team_create_modal_btn_submit"
                         onclick="submit_create_team()">
-                    생성
+                    팀 생성
                 </button>
             </div>
         </div>
@@ -169,7 +169,7 @@
 
         function set_team_create_modal_mode(mode) {
             if (mode == "CREATE_TEAMWISH_MENTEE") {
-                $('#team_create_modal_title').text('멘티 스케줄 생성');
+                $('#team_create_modal_title').text('멘티 팀 생성');
             } else if (mode == "CREATE_TEAMWISH_MENTOR") {
                 $('#team_create_modal_title').text('멘토 팀 생성');
                 isMentorCreate = 1;
@@ -231,13 +231,13 @@
                         if (data.statusCode != 200) {
                             alert("생성에 실패했습니다.\n" + data.message);
                         } else {
-                            alert("등록되었습니다.")
+                            alert(tc_ajax_req_info.success_message);
                             isMentorCreate = 0;
                             tc_ajax_req_info.success();
                         }
                     },
                     error: (request, status, error) => {
-                        alert("서버상의 문제로 실패했습니다.\n" + request.status + "\nmessage: "
+                        alert("서버상의 문제로 실패했습니다.\n해당 문제가 지속적으로 발생되면 github issue에 제보해주세요.\n" + request.status + "\nmessage: "
                             + request.responseText + "\nerror:" + error);
                     }
                 }

--- a/src/main/resources/templates/fragment/team_matching_modal.html
+++ b/src/main/resources/templates/fragment/team_matching_modal.html
@@ -11,7 +11,7 @@
     <div class="modal-dialog modal-dialog-centered modal-lg">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="team_matching_modal_title">멘토 팀 생성</h5>
+                <h5 class="modal-title" id="team_matching_modal_title">멘토 등록</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal"
                         aria-label="Close"></button>
             </div>
@@ -76,7 +76,7 @@
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
                 <button type="button" class="btn btn-primary" id="team_matching_modal_btn_submit"
                         onclick="submit_matching_team()">
-                    생성
+                    맨토 등록
                 </button>
             </div>
         </div>
@@ -233,14 +233,14 @@
                     contentType: 'application/json',
                     success: (data) => {
                         if (data.statusCode != 200) {
-                            alert("생성에 실패했습니다.\n" + data.message);
+                            alert("등록에 실패했습니다.\n" + data.message);
                         } else {
-                            alert("등록되었습니다.");
+                            alert('해당 팀에 맨토로 등록되었습니다.');
                             window.location.href = '/mentor';
                         }
                     },
                     error: (request, status, error) => {
-                        alert("서버상의 문제로 실패했습니다.\n" + request.status + "\nmessage: "
+                        alert("서버상의 문제로 실패했습니다.\n 해당 문제가 지속적으로 발생되면 github issue에 제보해주세요.\n" + request.status + "\nmessage: "
                             + request.responseText + "\nerror:" + error);
                     }
                 }

--- a/src/main/resources/templates/fragment/team_viewer_modal.html
+++ b/src/main/resources/templates/fragment/team_viewer_modal.html
@@ -197,8 +197,6 @@
                 }
             } else {
                 let rst = team.members.some((member) => {
-                    console.log(member);
-                    console.log(currentUser);
                     return (currentUser.nickname == member.nickname &&
                         (member.memberRole == "멘토" || member.creator));
                 });

--- a/src/main/resources/templates/fragment/team_viewer_modal.html
+++ b/src/main/resources/templates/fragment/team_viewer_modal.html
@@ -188,7 +188,7 @@
 
             if (team.status == 'WAITING') {
                 let rst = team.members.some((member) => {
-                    return (currentUser.nickname == member.nickname && member.isCreator);
+                    return (currentUser.nickname == member.nickname && member.creator);
                 });
                 if (rst) {
                     $('#tv_team_viewer_modal_btn_submit').text('팀 삭제');
@@ -200,7 +200,7 @@
                     console.log(member);
                     console.log(currentUser);
                     return (currentUser.nickname == member.nickname &&
-                        (member.memberRole == "멘토" || member.isCreator));
+                        (member.memberRole == "멘토" || member.creator));
                 });
                 if (rst) {
                     $('#tv_team_viewer_modal_btn_submit').attr('disabled', 'disabled');

--- a/src/main/resources/templates/fragment/team_viewer_modal.html
+++ b/src/main/resources/templates/fragment/team_viewer_modal.html
@@ -74,7 +74,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                <button type="button" class="btn btn-primary" id="tv_team_viewer_modal_btn_submit"
+                <button type="button" class="btn" id="tv_team_viewer_modal_btn_submit"
                         onclick="submit_viewer_team()">참여
                 </button>
             </div>
@@ -87,6 +87,7 @@
         var tv_ajax_req_info = undefined;
         var tv_team = undefined;
         var tv_startDate = new Date(2020, 0, 1, 0, 0, 0).valueOf();
+        var currentUser = undefined;
 
         $("#tv_input_time_rangeslider").ionRangeSlider({
             skin: "round",
@@ -171,6 +172,40 @@
             $('#tv_input_datepicker').val(moment(team.startTime).format('YYYY-MM-DD'));
             $('#tv_input_max_member_count').val(team.maxMemberCount);
             $('#tv_create_team_form').attr('team_id', team.teamId);
+
+            $.ajax({
+                    type: 'GET',
+                    url: './api/v1/user/current',
+                    data: null,
+                    dataType: "JSON",
+                    contentType: 'application/json',
+                    async: false,
+                    success: (data) => {
+                        currentUser = data.data;
+                    }
+                }
+            );
+
+            if (team.status == 'WAITING') {
+                let rst = team.members.some((member) => {
+                    return (currentUser.nickname == member.nickname && member.isCreator);
+                });
+                if (rst) {
+                    $('#tv_team_viewer_modal_btn_submit').text('팀 삭제');
+                    tv_ajax_req_info.url = './api/v1/team/' + team.teamId;
+                    tv_ajax_req_info.success_message = '해당 팀을 삭제했습니다.'
+                }
+            } else {
+                let rst = team.members.some((member) => {
+                    console.log(member);
+                    console.log(currentUser);
+                    return (currentUser.nickname == member.nickname &&
+                        (member.memberRole == "멘토" || member.isCreator));
+                });
+                if (rst) {
+                    $('#tv_team_viewer_modal_btn_submit').attr('disabled', 'disabled');
+                }
+            }
         }
 
         function reset_team_viewer_modal_info() {
@@ -197,21 +232,30 @@
             selected_opt_location.attr("selected", "selected");
 
             $('#tv_input_max_member_count').val(2);
+            $('#tv_team_viewer_modal_btn_submit').text('');
+            $('#tv_team_viewer_modal_btn_submit').removeAttr('disabled');
+            $('#tv_team_viewer_modal_btn_submit').removeClass('btn-danger');
+            $('#tv_team_viewer_modal_btn_submit').removeClass('btn-primary');
+
         }
 
         function set_team_viewer_modal_mode(mode) {
             if (mode == "READONLY_JOIN") {
-                $('#tv_team_viewer_modal_btn_submit').text('참가');
+                if ($('#tv_team_viewer_modal_btn_submit').text() == '')
+                    $('#tv_team_viewer_modal_btn_submit').text('팀 가입');
+                $('#tv_team_viewer_modal_btn_submit').addClass('btn-primary');
             } else if (mode == 'READONLY_OUT') {
-                $('#tv_team_viewer_modal_btn_submit').text('탈퇴');
+                if ($('#tv_team_viewer_modal_btn_submit').text() == '')
+                    $('#tv_team_viewer_modal_btn_submit').text('팀 탈퇴');
+                $('#tv_team_viewer_modal_btn_submit').addClass('btn-danger');
             }
         }
 
         function team_viewer_modal_update(data) {
-            if (data == undefined) return;
-            if (data.mode != undefined) set_team_viewer_modal_mode(data.mode);
-            if (data.team != undefined) set_team_viewer_modal_info(data.team);
             if (data.ajax_req_info != undefined) tv_ajax_req_info = data.ajax_req_info;
+            if (data == undefined) return;
+            if (data.team != undefined) set_team_viewer_modal_info(data.team);
+            if (data.mode != undefined) set_team_viewer_modal_mode(data.mode);
         }
 
         function team_viewer_modal_show() {
@@ -231,12 +275,12 @@
                         if (data.statusCode != 200) {
                             alert("처리 도중 문제가 발생했습니다.\n" + data.message);
                         } else {
-                            alert("정상 처리되었습니다.")
+                            alert(tv_ajax_req_info.success_message);
                             tv_ajax_req_info.success();
                         }
                     },
                     error: (request, status, error) => {
-                        alert("서버상의 문제로 실패했습니다.\n" + request.status + "\nmessage: "
+                        alert("서버상의 문제로 실패했습니다.\n해당 문제가 지속적으로 발생되면 github issue에 제보해주세요.\n" + request.status + "\nmessage: "
                             + request.responseText + "\nerror:" + error);
                     }
                 }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -167,6 +167,7 @@
                 ajax_req_info: {
                     url: './api/v1/team/' + team.teamId + '/out',
                     type: 'DELETE',
+                    success_message: '해당 팀에서 탈퇴했습니다.',
                     success: function () {
                         window.location.href = '/';
                     }

--- a/src/main/resources/templates/list_team.html
+++ b/src/main/resources/templates/list_team.html
@@ -128,6 +128,7 @@
                 ajax_req_info: {
                     url: './api/v1/team/' + team.teamId + '/join',
                     type: 'POST',
+                    success_message: '해당 팀에 가입되었습니다.',
                     success: function () {
                         window.location.href = '/list_team';
                     }

--- a/src/main/resources/templates/mentee.html
+++ b/src/main/resources/templates/mentee.html
@@ -115,6 +115,7 @@
                 ajax_req_info: {
                     url: "./api/v1/team",
                     type: "POST",
+                    success_message: '팀을 생성했습니다',
                     success: function () {
                         window.location.href = '/mentee';
                     },

--- a/src/main/resources/templates/mentor.html
+++ b/src/main/resources/templates/mentor.html
@@ -119,6 +119,7 @@
                 ajax_req_info: {
                     url: "./api/v1/team",
                     type: "POST",
+                    success_message: '해당 팀에 맨토로 등록되었습니다.',
                     success: function () {
                         window.location.href = '/mentor';
                     },


### PR DESCRIPTION
Add: 현재 로그인된 유저의 정보를 가져오는 api 추가
Edit: success_message를 넘겨받아 ajax 작업 성공 후 해당 메세지 출력
Edit: 일부 메세지, 버튼명칭, 타이틀 명칭 수정
Fix: home에서 team_detail_info의 버튼이 유저의 조건에 따라
활성, 비활성화 및 명칭이 수정되도록 보수