### PR TITLE
추가: #120 sentry 연동

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-spring-boot-starter</artifactId>
+            <version>5.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.sentry</groupId>
+            <artifactId>sentry-logback</artifactId>
+            <version>5.0.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -32,3 +32,7 @@ spring.mail.username=${HELPER42_MAIL_ADDRESS}
 spring.mail.password=${HELPER42_MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+#Sentry
+sentry.dsn=${HELPER42_SENTRY_DSN}
+sentry.logging.minimum-event-level=error
+sentry.environment=develop

--- a/src/main/resources/application-release.properties
+++ b/src/main/resources/application-release.properties
@@ -32,3 +32,7 @@ spring.mail.username=${HELPER42_MAIL_ADDRESS}
 spring.mail.password=${HELPER42_MAIL_PASSWORD}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+#Sentry
+sentry.dsn=${HELPER42_SENTRY_DSN}
+sentry.logging.minimum-event-level=error
+sentry.environment=production


### PR DESCRIPTION
sentry 연동을 하였습니다. 
production환경 develop 환경 두개 만들어 놓았습니다. 

logback와 연동이 되어, 로그 발생이 될 시 sentry로 전달되게 됩니다. log 레벨은 error만 sentry로 보내도록 설정하였습니다.

error 발생시 이메일로 발생한 error 이슈가 가게 됩니다.

두 분 이메일로 owner 권한으로 초대해 드렸으니 확인 부탁드립니다.

이슈 #120 