### PR TITLE
추가: #236 팀목록 페이지에 프로젝트, 일정 정렬기능 추가

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -77,15 +77,18 @@ public class PageController {
 
     @GetMapping(value = "/list_myteam")
     public String myTeamList(Model model, @LoginUser SessionUser user,
-                             @RequestParam(value = "offset", required = false, defaultValue = "0") int offset) {
+                             @RequestParam(value = "offset", required = false, defaultValue = "0") int offset,
+                             @RequestParam(value = "sort", required = false, defaultValue = "id,desc") String sort) {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setNickname(user.getNickname());
         dto.setOffset(offset);
+        dto.setSort(sort);
         dto.setEndTimePrevious(LocalDateTime.now());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 
         model.addAttribute("teams", teams);
         model.addAttribute("user", user);
+        model.addAttribute("sort", sort);
         model.addAttribute("projects", projectService.findAllProjects());
         model.addAttribute("locations", teamService.findAllLocation());
 

--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -57,15 +57,18 @@ public class PageController {
 
     @GetMapping(value = "/list_team")
     public String teamList(Model model, @LoginUser SessionUser user,
-                           @RequestParam(value = "offset", required = false, defaultValue = "0") int offset) {
+                           @RequestParam(value = "offset", required = false, defaultValue = "0") int offset,
+                           @RequestParam(value = "sort", required = false, defaultValue = "id,desc") String sort) {
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setOffset(offset);
         dto.setStartTimePrevious(LocalDateTime.now());
+        dto.setSort(sort);
         dto.setExcludeNickname(user.getNickname());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
 
         model.addAttribute("teams", teams);
         model.addAttribute("user", user);
+        model.addAttribute("sort", sort);
         model.addAttribute("projects", projectService.findAllProjects());
         model.addAttribute("locations", teamService.findAllLocation());
 

--- a/src/main/resources/templates/list_myteam.html
+++ b/src/main/resources/templates/list_myteam.html
@@ -5,6 +5,8 @@
       layout:decorator="layout/default_layout.html" th:with="currentPage='list_team'">
 <head>
     <title>Home</title>
+    <!-- sort icon -->
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 
 <div layout:fragment="custom-content">
@@ -36,10 +38,49 @@
             <thead>
             <tr>
                 <th scope="col">#</th>
-                <th scope="col">프로젝트 명칭</th>
+                <th scope="col">
+                    <div th:if="${#strings.contains(sort, 'project')}">
+                        <div th:if="${#strings.contains(sort, 'asc')}">
+                            <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,desc')}">
+                                프로젝트 명칭<i class="fa fa-fw fa-sort-asc"></i>
+                            </a>
+                        </div>
+                        <div th:if="${#strings.contains(sort, 'desc')}">
+                            <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,asc')}">
+                                프로젝트 명칭<i class="fa fa-fw fa-sort-desc"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div th:unless="${#strings.contains(sort, 'project')}">
+                        <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,asc')}">
+                            프로젝트 명칭<i class="fa fa-fw fa-sort"></i>
+                        </a>
+                    </div>
+                </th>
                 <th scope="col">제목</th>
                 <th scope="col">장소</th>
-                <th scope="col">일시</th>
+                <th scope="col">
+                    <div th:if="${#strings.contains(sort, 'startTime')}">
+                        <div th:if="${#strings.contains(sort, 'asc')}">
+                            <a class="text-reset text-decoration-none"
+                               th:href="@{/list_team(sort='period.startTime,desc')}">
+                                일시<i class="fa fa-fw fa-sort-asc"></i>
+                            </a>
+                        </div>
+                        <div th:if="${#strings.contains(sort, 'desc')}">
+                            <a class="text-reset text-decoration-none"
+                               th:href="@{/list_team(sort='period.startTime,asc')}">
+                                일시<i class="fa fa-fw fa-sort-desc"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div th:unless="${#strings.contains(sort, 'startTime')}">
+                        <a class="text-reset text-decoration-none"
+                           th:href="@{/list_myteam(sort='period.startTime,asc')}">
+                            일시<i class="fa fa-fw fa-sort"></i>
+                        </a>
+                    </div>
+                </th>
                 <th scope="col">인원</th>
                 <th scope="col">멘토</th>
                 <th scope="col">작업</th>
@@ -92,21 +133,24 @@
              aria-label="Page navigation">
             <ul class=" pagination justify-content-center">
                 <li th:if="${start > 1}" class="page-item">
-                    <a class="page-link" th:href="@{/list_myteam?(offset=0)}" th:text="'<<'"></a>
+                    <a class="page-link" th:href="@{/list_myteam(offset=0, sort=${sort})}" th:text="'<<'"></a>
                 </li>
                 <li th:if="${start > 1}" class="page-item">
-                    <a class="page-link" th:href="@{/list_myteam?(offset=${start - 2})}" th:text="'<'"></a>
+                    <a class="page-link" th:href="@{/list_myteam(offset=${start - 2}, sort=${sort})}" th:text="'<'"></a>
                 </li>
                 <li class="page-item"
                     th:each="offset: ${#numbers.sequence(start, end)}"
                     th:classappend="${offset == teams.number + 1} ? 'active'">
-                    <a class="page-link" th:href="@{/list_myteam?(offset=${offset - 1})}" th:text="${offset}"></a>
+                    <a class="page-link" th:href="@{/list_myteam(offset=${offset - 1}, sort=${sort})}"
+                       th:text="${offset}"></a>
                 </li>
                 <li th:if="${end < teams.totalPages}" class="page-item">
-                    <a class="page-link" th:href="@{/list_myteam?(offset=${start + maxPage - 1})}" th:text="'>'"></a>
+                    <a class="page-link" th:href="@{/list_myteam(offset=${start + maxPage - 1}, sort=${sort})}"
+                       th:text="'>'"></a>
                 </li>
                 <li th:if="${end < teams.totalPages}" class="page-item">
-                    <a class="page-link" th:href="@{/list_myteam?(offset=${teams.totalPages - 1})}" th:text="'>>'"></a>
+                    <a class="page-link" th:href="@{/list_myteam(offset=${teams.totalPages - 1}, sort=${sort})}"
+                       th:text="'>>'"></a>
                 </li>
             </ul>
         </nav>

--- a/src/main/resources/templates/list_team.html
+++ b/src/main/resources/templates/list_team.html
@@ -8,6 +8,9 @@
     <!-- Plugin CSS file with desired ski n-->
     <link rel="stylesheet"
           href="https://cdnjs.cloudflare.com/ajax/libs/ion-rangeslider/2.3.1/css/ion.rangeSlider.min.css"/>
+
+    <!-- sort icon -->
+    <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.1.0/css/font-awesome.min.css" rel="stylesheet">
 </head>
 
 <div layout:fragment="custom-content">
@@ -37,10 +40,48 @@
             <thead>
             <tr>
                 <th scope="col">#</th>
-                <th scope="col">프로젝트 명칭</th>
+                <th scope="col">
+                    <div th:if="${#strings.contains(sort, 'project')}">
+                        <div th:if="${#strings.contains(sort, 'asc')}">
+                            <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,desc')}">
+                                프로젝트 명칭<i class="fa fa-fw fa-sort-asc"></i>
+                            </a>
+                        </div>
+                        <div th:if="${#strings.contains(sort, 'desc')}">
+                            <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,asc')}">
+                                프로젝트 명칭<i class="fa fa-fw fa-sort-desc"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div th:unless="${#strings.contains(sort, 'project')}">
+                        <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='project,asc')}">
+                            프로젝트 명칭<i class="fa fa-fw fa-sort"></i>
+                        </a>
+                    </div>
+                </th>
                 <th scope="col">제목</th>
                 <th scope="col">장소</th>
-                <th scope="col">일시</th>
+                <th scope="col">
+                    <div th:if="${#strings.contains(sort, 'startTime')}">
+                        <div th:if="${#strings.contains(sort, 'asc')}">
+                            <a class="text-reset text-decoration-none"
+                               th:href="@{/list_team(sort='period.startTime,desc')}">
+                                일시<i class="fa fa-fw fa-sort-asc"></i>
+                            </a>
+                        </div>
+                        <div th:if="${#strings.contains(sort, 'desc')}">
+                            <a class="text-reset text-decoration-none"
+                               th:href="@{/list_team(sort='period.startTime,asc')}">
+                                일시<i class="fa fa-fw fa-sort-desc"></i>
+                            </a>
+                        </div>
+                    </div>
+                    <div th:unless="${#strings.contains(sort, 'startTime')}">
+                        <a class="text-reset text-decoration-none" th:href="@{/list_team(sort='period.startTime,asc')}">
+                            일시<i class="fa fa-fw fa-sort"></i>
+                        </a>
+                    </div>
+                </th>
                 <th scope="col">인원</th>
                 <th scope="col">멘토</th>
                 <th scope="col">작업</th>
@@ -98,21 +139,24 @@
              aria-label="Page navigation">
             <ul class=" pagination justify-content-center">
                 <li th:if="${start > 1}" class="page-item">
-                    <a class="page-link" th:href="@{/list_team?(offset=0)}" th:text="'<<'"></a>
+                    <a class="page-link" th:href="@{/list_team(offset=0, sort=${sort})}" th:text="'<<'"></a>
                 </li>
                 <li th:if="${start > 1}" class="page-item">
-                    <a class="page-link" th:href="@{/list_team?(offset=${start - 2})}" th:text="'<'"></a>
+                    <a class="page-link" th:href="@{/list_team(offset=${start - 2}, sort=${sort})}" th:text="'<'"></a>
                 </li>
                 <li class="page-item"
                     th:each="offset: ${#numbers.sequence(start, end)}"
                     th:classappend="${offset == teams.number + 1} ? 'active'">
-                    <a class="page-link" th:href="@{/list_team?(offset=${offset - 1})}" th:text="${offset}"></a>
+                    <a class="page-link" th:href="@{/list_team(offset=${offset - 1}, sort=${sort})}"
+                       th:text="${offset}"></a>
                 </li>
                 <li th:if="${end < teams.totalPages}" class="page-item">
-                    <a class="page-link" th:href="@{/list_team?(offset=${start + maxPage - 1})}" th:text="'>'"></a>
+                    <a class="page-link" th:href="@{/list_team(offset=${start + maxPage - 1}, sort=${sort})}"
+                       th:text="'>'"></a>
                 </li>
                 <li th:if="${end < teams.totalPages}" class="page-item">
-                    <a class="page-link" th:href="@{/list_team?(offset=${teams.totalPages - 1})}" th:text="'>>'"></a>
+                    <a class="page-link" th:href="@{/list_team(offset=${teams.totalPages - 1}, sort=${sort})}"
+                       th:text="'>>'"></a>
                 </li>
             </ul>
         </nav>


### PR DESCRIPTION
팀목록 페이지에 프로젝트와 일정 정렬기능만 추가하였습니다. 
thymeleaf 로 해결했네요. JS 공부가 필요합니다 ㅠㅠ

이슈: #236 