### PR TITLE
개선: #302 application.yaml spring.profile 교체

### DIFF
--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,8 +1,9 @@
 spring:
-  profiles:
-    include:
-      - oauth
-      - mail
+  config:
+    activate:
+      on-profile:
+        - oauth
+        - mail
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     username: "${HELPER42_DB_USERNAME}"

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -1,9 +1,8 @@
 spring:
   config:
-    activate:
-      on-profile:
-        - oauth
-        - mail
+    import:
+      - "classpath:/application-oauth.yaml"
+      - "classpath:/application-mail.yaml"
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     username: "${HELPER42_DB_USERNAME}"

--- a/src/main/resources/application-release.yaml
+++ b/src/main/resources/application-release.yaml
@@ -1,8 +1,9 @@
 spring:
-  profiles:
-    include:
-      - oauth
-      - mail
+  config:
+    activate:
+      on-profile:
+        - oauth
+        - mail
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     username: "${HELPER42_DB_USERNAME_RELEASE}"

--- a/src/main/resources/application-release.yaml
+++ b/src/main/resources/application-release.yaml
@@ -1,9 +1,8 @@
 spring:
   config:
-    activate:
-      on-profile:
-        - oauth
-        - mail
+    import:
+      - "classpath:/application-oauth.yaml"
+      - "classpath:/application-mail.yaml"
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
     username: "${HELPER42_DB_USERNAME_RELEASE}"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,9 +1,8 @@
 spring:
   config:
-    activate:
-      on-profile:
-        - oauth
-        - mail
+    import:
+      - "classpath:/application-oauth.yaml"
+      - "classpath:/application-mail.yaml"
   datasource:
     embedded-database-connection: "h2"
   sql:
@@ -18,7 +17,6 @@ spring:
     properties:
       hibernate:
         default_batch_fetch_size: 100
-
 server:
   port: 8080
   error:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,8 +1,9 @@
 spring:
-  profiles:
-    include:
-      - oauth
-      - mail
+  config:
+    activate:
+      on-profile:
+        - oauth
+        - mail
   datasource:
     embedded-database-connection: "h2"
   sql:


### PR DESCRIPTION
개선: oauth, mail yaml 파일을 읽지 못하는 버그 수정
Spring 2.4 버전 이후 spring.profile 이 deprecated 되었습니다.
이로인해 config 방식으로 교체합니다.

issue #302 