### PR TITLE
fixes #313 : reiview button 의 비활성화 문제 수정

### DIFF
--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamResponseDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamResponseDto.java
@@ -50,6 +50,7 @@ public class TeamResponseDto {
                         .nickname(member.getUser().getNickname())
                         .memberRole(member.getRole().getName())
                         .creator(member.getCreator())
+                        .participation(member.getParticipation())
                         .build())
                 .collect(Collectors.toList());
         this.subject = team.getSubject();


### PR DESCRIPTION
수정: TeamResponseDto에서 memberResponseDto 에 participation 데이터 추가
modal 창 활성화 시 member 의 participation 를 체크하고 true 인 맴버만 버튼을 활성화하는데 TeamResponseDto 에서 이를 담지 않아 생긴 미스

issue #313 