### PR TITLE
resolve : #315 close, review 페이지의 비정상 접근 차단

### DIFF
--- a/src/main/resources/templates/close_team.html
+++ b/src/main/resources/templates/close_team.html
@@ -51,6 +51,32 @@
 </body>
 <div layout:fragment="custom-footer">
     <script>
+        window.onload = function () {
+            let team_id = document.getElementById('close_team_input_team_id').value;
+            if (team_id < 0) {
+                alert('비정상 접근입니다.');
+                window.location.href = '/';
+                return undefined;
+            }
+
+            fetch('/api/v1/team/' + team_id, {method: 'GET'})
+                .then(response => {
+                    if (response.status !== 200)
+                        throw new Error("서버상의 문제로 접근할 수 없습니다.");
+                    return response.json();
+                })
+                .then(data => {
+                    if (data.statusCode !== 200)
+                        throw new Error("잘못된 접근입니다.");
+                    if (data.data.status !== 'FULL' && data.data.status !== 'READY')
+                        throw new Error("해당 팀 상태가 유효하지 않습니다.")
+                })
+                .catch(err => {
+                    alert(err);
+                    window.location.href = '/';
+                });
+        }
+
         function close_team_submit(event) {
             const m = document.getElementsByClassName('member');
             let members = [];

--- a/src/main/resources/templates/review.html
+++ b/src/main/resources/templates/review.html
@@ -73,6 +73,15 @@
 </body>
 <div layout:fragment="custom-footer">
     <script>
+        window.onload = function () {
+            /* check review is valid or access is valid */
+            let review_id = document.getElementById('review_input_id').value;
+            if (review_id < 0) {
+                alert("해당 페이지는 이미 만료되었거나 접근할 수 없습니다");
+                window.location.href = '/';
+            }
+        }
+
         function review_team_submit(event) {
             let review_id = document.getElementById('review_input_id').value;
             let description = document.getElementById('review_textarea_description').value;


### PR DESCRIPTION
수정: review 페이지에서 review_id 가 -1인 경우 비정상 접근으로 판단하여 홈화면으로 돌아갑니다.
수정: close_team 페이지에서 team_id를 통해 팀 조회 시 팀의 상태가 full, ready 상태가 아니라면 비정상 접근으로 판단하여 홈 화면으로 돌아갑니다.