### PR TITLE
2021 08 26 배포

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Controller
 @AllArgsConstructor
@@ -32,20 +34,36 @@ public class PageController {
         if (user == null) {
             TeamListRequestDto dto = new TeamListRequestDto();
             dto.setStartTimePrevious(LocalDateTime.now());
+            List<TeamStatus> activeTeamStatusList = new ArrayList<>();
+            activeTeamStatusList.add(TeamStatus.WAITING);
+            activeTeamStatusList.add(TeamStatus.READY);
+            activeTeamStatusList.add(TeamStatus.FULL);
+            dto.setStatusList(activeTeamStatusList);
             Page<TeamResponseDto> teams = teamService.findTeams(dto);
             model.addAttribute("teams", teams);
         }
         if (user != null) {
+            List<TeamStatus> activeTeamStatusList = new ArrayList<>();
+            activeTeamStatusList.add(TeamStatus.WAITING);
+            activeTeamStatusList.add(TeamStatus.READY);
+            activeTeamStatusList.add(TeamStatus.FULL);
             TeamListRequestDto allTeamDto = new TeamListRequestDto();
             allTeamDto.setStartTimePrevious(LocalDateTime.now());
             allTeamDto.setExcludeNickname(user.getNickname());
+            allTeamDto.setStatusList(activeTeamStatusList);
             Page<TeamResponseDto> allTeams = teamService.findTeams(allTeamDto);
             model.addAttribute("allTeams", allTeams);
 
+            List<TeamStatus> myTeamStatusList = new ArrayList<>();
+            myTeamStatusList.add(TeamStatus.WAITING);
+            myTeamStatusList.add(TeamStatus.READY);
+            myTeamStatusList.add(TeamStatus.FULL);
+            myTeamStatusList.add(TeamStatus.REVIEW);
             TeamListRequestDto myTeamDto = new TeamListRequestDto();
             myTeamDto.setEndTimePrevious(LocalDateTime.now());
             myTeamDto.setNickname(user.getNickname());
             myTeamDto.setSort("period.startTime,asc");
+            myTeamDto.setStatusList(myTeamStatusList);
             Page<TeamResponseDto> myTeams = teamService.findTeams(myTeamDto);
             model.addAttribute("myTeams", myTeams);
 
@@ -104,11 +122,13 @@ public class PageController {
             model.addAttribute("userNickname", user.getNickname());
             model.addAttribute("user", user);
         }
+        List<TeamStatus> statusList = new ArrayList<>();
+        statusList.add(TeamStatus.WAITING);
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setNickname(user.getNickname());
         dto.setCreateor(true);
         dto.setOffset(offset);
-        dto.setStatus(TeamStatus.WAITING);
+        dto.setStatusList(statusList);
         dto.setEndTimePrevious(LocalDateTime.now());
         Page<TeamResponseDto> teams = teamService.findTeams(dto);
         model.addAttribute("teams", teams);
@@ -121,10 +141,11 @@ public class PageController {
     public String createMentor(Model model, @LoginUser SessionUser user,
                                @RequestParam(value = "offset", required = false, defaultValue = "0") int offset) {
 
-        TeamStatus status = TeamStatus.WAITING;
+        List<TeamStatus> statusList = new ArrayList<>();
+        statusList.add(TeamStatus.WAITING);
 
         TeamListRequestDto dto = new TeamListRequestDto();
-        dto.setStatus(status);
+        dto.setStatusList(statusList);
         dto.setOffset(offset);
         dto.setStartTimePrevious(LocalDateTime.now());
         dto.setExcludeNickname(user.getNickname());

--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamListRequestDto.java
@@ -7,6 +7,7 @@ import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 public class TeamListRequestDto {
@@ -16,7 +17,7 @@ public class TeamListRequestDto {
     private String excludeNickname;
     private MemberRole memberRole;
     private boolean isCreateor;
-    private TeamStatus status;
+    private List<TeamStatus> statusList;
     private TeamLocation location;
     private String sort;
 

--- a/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
+++ b/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
@@ -15,30 +15,30 @@ import java.util.List;
 @Repository
 public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("SELECT t FROM Team t " +
-            "WHERE (:status is null or t.status = :status) and " +
+            "WHERE ((:statusList) is null or t.status IN (:statusList)) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
             "(:endTimePrevious is null or t.period.endTime > :endTimePrevious)")
     Page<Team> findTeamsByQueryParameters(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious,
-                                          TeamStatus status, TeamLocation location, Pageable pageable);
+                                          List<TeamStatus> statusList, TeamLocation location, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +
-            "WHERE (:status is null or t.status = :status) and " +
+            "WHERE ((:statusList) is null or t.status in (:statusList)) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
             "(:endTimePrevious is null or t.period.endTime > :endTimePrevious) and " +
             "t.id IN :teamId")
-    Page<Team> findTeamsByTeamIdIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious, TeamStatus status,
-                                   TeamLocation location, List<Long> teamId, Pageable pageable);
+    Page<Team> findTeamsByTeamIdIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious,
+                                   List<TeamStatus> statusList, TeamLocation location, List<Long> teamId, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +
-            "WHERE (:status is null or t.status = :status) and " +
+            "WHERE ((:statusList) is null or t.status in (:statusList)) and " +
             "(:location is null or t.location = :location) and " +
             "(:startTimePrevious is null or t.period.startTime > :startTimePrevious) and " +
             "(:endTimePrevious is null or t.period.endTime > :endTimePrevious) and " +
             "t.id NOT IN :teamId")
-    Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious, TeamStatus status,
-                                      TeamLocation location, List<Long> teamId, Pageable pageable);
+    Page<Team> findTeamsByTeamIdNotIn(LocalDateTime startTimePrevious, LocalDateTime endTimePrevious,
+                                      List<TeamStatus> statusList, TeamLocation location, List<Long> teamId, Pageable pageable);
 
     @Query("SELECT DISTINCT t FROM Team t " +
             "WHERE (:status is null or t.status <> :status) and " +

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -184,24 +184,24 @@ public class TeamService {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getNickname(), requestDto.isCreateor(), requestDto.getMemberRole());
 
                 teams = teamRepo.findTeamsByTeamIdIn(
-                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
+                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatusList(),
                         requestDto.getLocation(), teamIds, pageable);
             } else if (requestDto.getExcludeNickname() != null) {
                 List<Long> teamIds = findTeamIdsByNickname(requestDto.getExcludeNickname(), requestDto.isCreateor(), requestDto.getMemberRole());
 
                 if (teamIds.isEmpty()) {
                     teams = teamRepo.findTeamsByQueryParameters(
-                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
+                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatusList(),
                             requestDto.getLocation(), pageable);
                 } else {
                     teams = teamRepo.findTeamsByTeamIdNotIn(
-                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
+                            requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatusList(),
                             requestDto.getLocation(), teamIds, pageable);
                 }
 
             } else {
                 teams = teamRepo.findTeamsByQueryParameters(
-                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatus(),
+                        requestDto.getStartTimePrevious(), requestDto.getEndTimePrevious(), requestDto.getStatusList(),
                         requestDto.getLocation(), pageable);
             }
         } catch (Exception e) {

--- a/src/main/resources/db/h2/data.sql
+++ b/src/main/resources/db/h2/data.sql
@@ -102,34 +102,34 @@ values (30, 'ft_transcendence');
 /*Team*/
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (1, '2021-08-03 13:00:00', '2021-08-03 15:00:00', 'GAEPO', 3, 'READY', 2, '제목입니다', '설명입니다');
+values (1, '2022-08-03 13:00:00', '2022-08-03 15:00:00', 'GAEPO', 3, 'READY', 2, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (2, '2021-08-04 13:00:00', '2021-08-04 18:00:00', 'ONLINE', 4, 'WAITING', 3, '제목입니다', '설명입니다');
+values (2, '2022-08-04 13:00:00', '2022-08-04 18:00:00', 'ONLINE', 4, 'WAITING', 3, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (3, '2021-08-04 11:00:00', '2021-08-04 19:00:00', 'SEOCHO', 4, 'READY', 4, '제목입니다', '설명입니다');
+values (3, '2022-08-04 11:00:00', '2022-08-04 19:00:00', 'SEOCHO', 4, 'READY', 4, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (4, '2021-08-04 13:00:00', '2021-08-04 15:00:00', 'GAEPO', 4, 'WAITING', 2, '제목입니다', '설명입니다');
+values (4, '2022-08-04 13:00:00', '2022-08-04 15:00:00', 'GAEPO', 4, 'WAITING', 2, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (5, '2021-08-01 13:00:00', '2021-08-01 15:00:00', 'ONLINE', 3, 'FULL', 2, '제목입니다', '설명입니다');
+values (5, '2022-08-01 13:00:00', '2022-08-01 15:00:00', 'ONLINE', 3, 'FULL', 2, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (6, '2021-08-06 15:00:00', '2021-08-06 16:00:00', 'GAEPO', 3, 'WAITING', 3, '제목입니다', '설명입니다');
+values (6, '2022-08-06 15:00:00', '2022-08-06 16:00:00', 'GAEPO', 3, 'WAITING', 3, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (7, '2021-08-10 13:00:00', '2021-08-10 15:00:00', 'ONLINE', 10, 'READY', 4, '제목입니다', '설명입니다');
+values (7, '2022-08-10 13:00:00', '2022-08-10 15:00:00', 'ONLINE', 10, 'READY', 4, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (8, '2021-08-10 12:00:00', '2021-08-10 15:00:00', 'ONLINE', 3, 'WAITING', 4, '제목입니다', '설명입니다');
+values (8, '2022-08-10 12:00:00', '2022-08-10 15:00:00', 'ONLINE', 3, 'WAITING', 4, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (9, '2021-08-30 09:00:00', '2021-08-30 12:00:00', 'ONLINE', 3, 'END', 1, '제목입니다', '설명입니다');
+values (9, '2022-08-30 09:00:00', '2022-08-30 12:00:00', 'ONLINE', 3, 'END', 1, '제목입니다', '설명입니다');
 insert into team (id, start_time, end_time, location, max_member_count, status,
                   project_id, subject, description)
-values (10, '2021-08-22 09:00:00', '2021-08-22 12:00:00', 'ONLINE', 2, 'WAITING', 1, '제목입니다', '설명입니다');
+values (10, '2022-08-22 09:00:00', '2022-08-22 12:00:00', 'ONLINE', 2, 'WAITING', 1, '제목입니다', '설명입니다');
 
 /*member*/
 insert into member (id, team_id, user_id, role, creator, participation)


### PR DESCRIPTION
* Edit : data.sql team 날짜 수정

수정 : 예제팀 기간 연장 2021y => 2022y

* resolve #310 : TeamStatus 일부 상태 표기 및 미표기 상황 수정

이제는 TeamStatus가 유효하지 않은 경우 (Timeout, end, Revoke) 페이지에 표기되지 않습니다.

수정 : jpql TeamStatus 조회를 'in' 으로 변경
수정 : Controller 에서 TeamRequest 요청 시 TeamStatus를 List로 받도록 수정