### PR TITLE
fixes #337 : 시간에 따른 팀 미표기 문제 해결

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -60,7 +60,6 @@ public class PageController {
             myTeamStatusList.add(TeamStatus.FULL);
             myTeamStatusList.add(TeamStatus.REVIEW);
             TeamListRequestDto myTeamDto = new TeamListRequestDto();
-            myTeamDto.setEndTimePrevious(LocalDateTime.now());
             myTeamDto.setNickname(user.getNickname());
             myTeamDto.setSort("period.startTime,asc");
             myTeamDto.setStatusList(myTeamStatusList);
@@ -107,7 +106,7 @@ public class PageController {
         dto.setNickname(user.getNickname());
         dto.setOffset(offset);
         dto.setSort(sort);
-        dto.setEndTimePrevious(LocalDateTime.now());
+        dto.setEndTimePrevious(null);
         List<TeamStatus> statusList = new ArrayList<>();
         statusList.add(TeamStatus.WAITING);
         statusList.add(TeamStatus.READY);


### PR DESCRIPTION
하나의 dto를 공유해서 쓰다보니 timefield 에 데이터가 추가되여 이러한 문제로 인해 원하는 데이터가 제대로 걸려지지 않는 문제가 발생하고 있습니다.
임시로 controller 에서 해당 field null로 교체하여 변경했지만 이는 차후 의논을 통해 수정이 필요할 것 같습니다.