### PR TITLE
추가: #341 시간 중복 로직 추가

### DIFF
--- a/src/main/java/io/seoul/helper/controller/team/dto/TeamDateDto.java
+++ b/src/main/java/io/seoul/helper/controller/team/dto/TeamDateDto.java
@@ -1,0 +1,22 @@
+package io.seoul.helper.controller.team.dto;
+
+import lombok.Getter;
+
+@Getter
+public class TeamDateDto {
+        int month;
+        int day;
+        int startHour;
+        int startMinute;
+        int endHour;
+        int endMinus;
+
+        public TeamDateDto(TeamCreateRequestDto request) {
+            this.month = request.getStartTime().getMonthValue();
+            this.day = request.getStartTime().getDayOfMonth();
+            this.startHour = request.getStartTime().getHour();
+            this.startMinute = request.getStartTime().getMinute();
+            this.endHour = request.getEndTime().getHour();
+            this.endMinus = request.getEndTime().getMinute();
+        }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,6 +7,9 @@ spring:
     allow-bean-definition-overriding: true
   datasource:
     embedded-database-connection: "h2"
+    url: "jdbc:h2:tcp://localhost/~/test"
+    username: "sa"
+    password: ""
   sql:
     init:
       data-locations: classpath*:db/h2/data.sql

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -7,9 +7,6 @@ spring:
     allow-bean-definition-overriding: true
   datasource:
     embedded-database-connection: "h2"
-    url: "jdbc:h2:tcp://localhost/~/test"
-    username: "sa"
-    password: ""
   sql:
     init:
       data-locations: classpath*:db/h2/data.sql


### PR DESCRIPTION
팀 생성 시 시간이 중복되는 경우에도 팀을 생성하는 이슈가 있었습니다.
팀 생성 시 시간이 중복되는 멘토링이 없는지 확인하고 있다면 팀 생성이 안되게 만들었습니다.