### PR TITLE
[Bug] 한팀에 멘토 중복 신청 버그 수정

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -155,8 +155,6 @@ public class PageController {
 
         List<TeamStatus> statusList = new ArrayList<>();
         statusList.add(TeamStatus.WAITING);
-        statusList.add(TeamStatus.READY);
-        statusList.add(TeamStatus.FULL);
 
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setStatusList(statusList);

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -95,7 +95,6 @@ public class TeamService {
                 .role(MemberRole.MENTOR)
                 .creator(false)
                 .build());
-        List<Member> members = team.getMembers();
         return new TeamResponseDto(team);
     }
 

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -75,6 +75,8 @@ public class TeamService {
         User user = userRepo.getById(userService.findUserBySession(currentUser).getId());
         Team team = teamRepo.findById(teamId)
                 .orElseThrow(() -> new EntityNotFoundException("Team is not exist"));
+        if (team.getStatus() != TeamStatus.WAITING)
+            throw new Exception("The team already has mentor");
         Project project = projectRepo.getById(requestDto.getProjectId());
         if (memberRepo.findMemberByTeamAndUser(team, user).isPresent())
             throw new Exception("Not valid member");


### PR DESCRIPTION
한팀에 중복된 멘토가 신청되는 버그가 발생했습니다.

이를 막기 위해 
1. 서버에서는 해당 Team이 Waiting(멘토가 존재) 하는지 체크하고, 위반시 에러를 반환하며
2. Controller 에서는 /mentor 페이지에서  Waiting 외의 상태인 팀이 조회되지 않게 막아

backend 에서든, frontend 쪽에서든 접근할 수 없게 변경했습니다.