### PR TITLE
2021 09 18 1차 배포 

### DIFF
--- a/src/main/java/io/seoul/helper/controller/PageController.java
+++ b/src/main/java/io/seoul/helper/controller/PageController.java
@@ -155,8 +155,6 @@ public class PageController {
 
         List<TeamStatus> statusList = new ArrayList<>();
         statusList.add(TeamStatus.WAITING);
-        statusList.add(TeamStatus.READY);
-        statusList.add(TeamStatus.FULL);
 
         TeamListRequestDto dto = new TeamListRequestDto();
         dto.setStatusList(statusList);

--- a/src/main/java/io/seoul/helper/service/TeamService.java
+++ b/src/main/java/io/seoul/helper/service/TeamService.java
@@ -75,6 +75,8 @@ public class TeamService {
         User user = userRepo.getById(userService.findUserBySession(currentUser).getId());
         Team team = teamRepo.findById(teamId)
                 .orElseThrow(() -> new EntityNotFoundException("Team is not exist"));
+        if (team.getStatus() != TeamStatus.WAITING)
+            throw new Exception("The team already has mentor");
         Project project = projectRepo.getById(requestDto.getProjectId());
         if (memberRepo.findMemberByTeamAndUser(team, user).isPresent())
             throw new Exception("Not valid member");
@@ -93,7 +95,6 @@ public class TeamService {
                 .role(MemberRole.MENTOR)
                 .creator(false)
                 .build());
-        List<Member> members = team.getMembers();
         return new TeamResponseDto(team);
     }
 


### PR DESCRIPTION
* fixes #344 : 한팀에 중복된 멘토 신청 문제 해결

Add : TeamService 에서 멘토의 참여 시, 해당 팀이 waiting 상태가 아니라면 에러코드를 반환함
Fix : PageController 에서 /mentor 에 Team조회 시 Waiting 상태의 팀만 조회하도록 설정

* Edit : 미사용 코드 제거

디버그용 코드로 추정,
해당 객체는 어디에서도 사용되지 않음으로 삭제함