### PR TITLE
resolve #351 : 멘토 리뷰 기능 추가 및 front 안전장치 추가

### DIFF
--- a/src/main/java/io/seoul/helper/controller/review/ReviewApiController.java
+++ b/src/main/java/io/seoul/helper/controller/review/ReviewApiController.java
@@ -4,13 +4,12 @@ import io.seoul.helper.config.aop.ApiControllerTryCatch;
 import io.seoul.helper.config.auth.LoginUser;
 import io.seoul.helper.config.auth.dto.SessionUser;
 import io.seoul.helper.controller.dto.ResultResponseDto;
+import io.seoul.helper.controller.review.dto.ReviewResponseDto;
 import io.seoul.helper.controller.review.dto.ReviewUpdateRequestDto;
 import io.seoul.helper.service.ReviewService;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @AllArgsConstructor
@@ -27,6 +26,17 @@ public class ReviewApiController {
                 .statusCode(HttpStatus.OK.value())
                 .message("OK")
                 .data(null)
+                .build();
+    }
+
+    @ApiControllerTryCatch
+    @GetMapping(value = "/api/v1/review")
+    public ResultResponseDto findReviewByMember(@RequestParam Long memberId) throws Exception {
+        ReviewResponseDto dto = reviewService.findReviewByMemberId(memberId);
+        return ResultResponseDto.builder()
+                .statusCode(HttpStatus.OK.value())
+                .message("OK")
+                .data(dto)
                 .build();
     }
 }

--- a/src/main/java/io/seoul/helper/controller/review/dto/ReviewResponseDto.java
+++ b/src/main/java/io/seoul/helper/controller/review/dto/ReviewResponseDto.java
@@ -1,5 +1,6 @@
 package io.seoul.helper.controller.review.dto;
 
+import io.seoul.helper.domain.review.ReviewStatus;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -8,11 +9,13 @@ public class ReviewResponseDto {
     private Long id;
     private String description;
     private ScoreDto score;
+    private ReviewStatus status;
 
     @Builder
-    public ReviewResponseDto(Long id, String description, ScoreDto score) {
+    public ReviewResponseDto(Long id, String description, ScoreDto score, ReviewStatus status) {
         this.id = id;
         this.description = description;
         this.score = score;
+        this.status = status;
     }
 }

--- a/src/main/java/io/seoul/helper/service/TeamInnerService.java
+++ b/src/main/java/io/seoul/helper/service/TeamInnerService.java
@@ -1,7 +1,6 @@
 package io.seoul.helper.service;
 
 import io.seoul.helper.domain.member.Member;
-import io.seoul.helper.domain.member.MemberRole;
 import io.seoul.helper.domain.review.Review;
 import io.seoul.helper.domain.review.ReviewStatus;
 import io.seoul.helper.domain.team.Team;
@@ -32,7 +31,7 @@ public class TeamInnerService {
         if (members.stream().anyMatch(m -> m.getParticipation() == null))
             return;
         if (members.stream()
-                .filter(m -> m.getParticipation() && m.getRole() != MemberRole.MENTOR)
+                .filter(m -> m.getParticipation())
                 .map(m -> reviewRepo.findReviewByTeamAndUser(m.getTeam(), m.getUser())
                         .orElseGet(() -> Review.builder()
                                 .status(ReviewStatus.WAIT)

--- a/src/main/resources/templates/close_team.html
+++ b/src/main/resources/templates/close_team.html
@@ -78,6 +78,11 @@
         }
 
         function close_team_submit(event) {
+            let confirm_answer = confirm("팀을 종료하겠습니까?");
+            if (!confirm_answer) {
+                event.preventDefault();
+                return;
+            }
             const m = document.getElementsByClassName('member');
             let members = [];
             const team_id = document.getElementById('close_team_input_team_id').value;

--- a/src/main/resources/templates/fragment/team_viewer_modal.html
+++ b/src/main/resources/templates/fragment/team_viewer_modal.html
@@ -271,9 +271,24 @@
                 }
                 case 'REVIEW': {
                     let rst = team.members.some((member) => {
-                        return (currentUser.nickname == member.nickname &&
-                            member.memberRole != "멘토" && member.participation == true);
+                        let review;
+                        $.ajax({
+                                type: 'GET',
+                                url: './api/v1/review?memberId=' + member.id,
+                                data: null,
+                                dataType: "JSON",
+                                contentType: 'application/json',
+                                async: false,
+                                success: (data) => {
+                                    review = data.data;
+                                }
+                            }
+                        );
+                        return (currentUser.nickname == member.nickname && member.participation == true
+                            && review != null && review.status == "WAIT");
                     });
+
+
                     if (rst) {
                         $('#tv_team_viewer_modal_btn_review').removeAttr('hidden');
                     }

--- a/src/main/resources/templates/review.html
+++ b/src/main/resources/templates/review.html
@@ -91,6 +91,11 @@
                 time: document.getElementById('review_input_time').value,
                 interested: document.getElementById('review_input_interested').value,
             }
+            if (description.length <= 10) {
+                alert("리뷰 내용이 너무 적습니다. 차후 평가에 반영되니 상세히 적어주세요");
+                event.preventDefault();
+                return;
+            }
             fetch('/api/v1/review', {
                 method: 'POST',
                 headers: {

--- a/src/test/java/io/seoul/helper/service/ReviewServiceTest.java
+++ b/src/test/java/io/seoul/helper/service/ReviewServiceTest.java
@@ -225,7 +225,7 @@ public class ReviewServiceTest {
     public void checkReview(User user, TeamReviewRequestDto requestDto) throws Exception {
         teamService.reviewTeam(new SessionUser(user), requestDto);
         Team team = teamRepo.getById(requestDto.getId());
-        List<User> users = memberRepo.findMembersByTeamAndAndRole(team, MemberRole.MENTEE).stream()
+        List<User> users = memberRepo.findMembersByTeam(team).stream()
                 .map(Member::getUser)
                 .collect(Collectors.toList());
         users.forEach(m -> checkReviewCreated(reviewRepo.findReviewByTeamAndUser(team, m)));


### PR DESCRIPTION
edit : ReviewService, 이제 멘토가 팀을 종료시 멘토에게도 리뷰를 작성하게 변경되었습니다.
edit : TeamInnerService, 이제 review 체크 범위를 멘토까지 확장시킵니다.
edit : team_review_modal, Review를 한번이라도 작성하면 이제 더이상 리뷰작성 버튼이 활성화 되지 않습니다.
edit : Review 작성 시 상세내역을 최소 10글자 이상을 서술해야 합니다.
edit : 팀 종료 시 알람창으로 한번 더 체크합니다.