### PR TITLE
resolve #234 : 팀의 시간 중복체크을 유저가 속한 팀으로 한정

### DIFF
--- a/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
+++ b/src/main/java/io/seoul/helper/repository/team/TeamRepository.java
@@ -69,10 +69,12 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     Integer findTeamCountByEndTimeRangeAndStatus(LocalDateTime start, LocalDateTime end, Set<TeamStatus> statusList);
 
     @Query("SELECT DISTINCT t FROM Team t " +
-            "WHERE (t.status NOT IN (:statusList)) and " +
+            "WHERE (t.id IN (SELECT m.team.id FROM Member m WHERE m.user.id = :userId)) and " +
+            "(t.status NOT IN (:statusList)) and " +
             "((t.period.startTime <= :startTime and t.period.endTime <= :endTime and t.period.endTime > :startTime) or" +
             "(t.period.startTime >= :startTime and t.period.endTime >= :endTime and t.period.startTime < :endTime) or" +
             "(t.period.startTime <= :startTime and t.period.endTime >= :endTime) or " +
             "(t.period.startTime >= :startTime and t.period.endTime <= :endTime))")
-    List<Team> findTeamsByDuplicateDateTime(List<TeamStatus> statusList, LocalDateTime startTime, LocalDateTime endTime);
+    List<Team> findTeamsByUserAndDuplicateDateTime(List<TeamStatus> statusList, Long userId,
+                                                   LocalDateTime startTime, LocalDateTime endTime);
 }

--- a/src/main/java/io/seoul/helper/service/MemberService.java
+++ b/src/main/java/io/seoul/helper/service/MemberService.java
@@ -32,6 +32,16 @@ public class MemberService {
         User user = userRepo.getById(userService.findUserBySession(currentUser).getId());
         Team team = teamRepo.findById(requestDto.getTeamId()).orElseThrow(() ->
                 new EntityNotFoundException("Team not exist"));
+        List<TeamStatus> statusList = new ArrayList<>();
+        statusList.add(TeamStatus.REVOKE);
+        statusList.add(TeamStatus.END);
+        teamRepo.findTeamsByUserAndDuplicateDateTime(statusList, user.getId(),
+                team.getPeriod().getStartTime(), team.getPeriod().getEndTime())
+                .stream()
+                .findAny()
+                .ifPresent(o -> {
+                    throw new RuntimeException("Time Overlap - Team #" + o.getId());
+                });
         if (memberRepo.findMemberByTeamAndUser(team, user).isPresent())
             throw new Exception("Already joined");
         if (team.getStatus() != TeamStatus.READY)

--- a/src/test/java/io/seoul/helper/service/ReviewServiceTest.java
+++ b/src/test/java/io/seoul/helper/service/ReviewServiceTest.java
@@ -72,7 +72,8 @@ public class ReviewServiceTest {
             addUsers();
             createTeams();
         } catch (Exception e) {
-            fail("fail : cannot create team");
+            log.error(e.getMessage());
+            fail("fail : cannot create team\nCause : " + e.getMessage());
         }
     }
 
@@ -133,8 +134,8 @@ public class ReviewServiceTest {
                 TeamCreateRequestDto.builder()
                         .subject("TEST TEAM MENTOR BUILD")
                         .description("TEST TEAM MENTOR BUILD")
-                        .startTime(startTime)
-                        .endTime(endTime)
+                        .startTime(startTime.plusDays(1))
+                        .endTime(endTime.plusDays(1))
                         .location(TeamLocation.ONLINE)
                         .maxMemberCount(4L)
                         .memberRole(MemberRole.MENTOR)
@@ -183,7 +184,7 @@ public class ReviewServiceTest {
     }
 
     @AfterAll
-    public void cleanup() throws Exception {
+    public void cleanup() {
         reviewList.forEach(r -> {
             reviewRepo.findById(r).ifPresent(o -> reviewRepo.delete(o));
         });


### PR DESCRIPTION
edit : 팀의 중복체크를 위한 repository의 findTeamsByDuplicateDateTime 함수의 팀 조회 범위를 해당 유저가 속해있는 팀으로 한정
edit : findTeamByDuplicateDateTime 에 User 조건이 추가되어 findTeamsByUserAndDuplicateDateTime 으로 명칭변경
edit : 시간중복의 [if - throw]를 [steam.optional.ifpresent - throw]로 변경
add : 시간중복 체크를 updateTeam, joinTeam에 적용
edit : TeamReviewTest에서 Test팀의 Period를 다르게 설정